### PR TITLE
Add ruff as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
   - id: check-added-large-files
 ## Python specific linting and formatting
 repos:
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.0.272
+      hooks:
+        - id: ruff        
+          args: [--fix, --exit-non-zero-on-fix]
     - repo: https://github.com/psf/black
       rev: 22.3.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,3 @@ repos:
       rev: 22.3.0
       hooks:
         - id: black
-    - repo: https://github.com/pycqa/pydocstyle
-      rev: 4.0.0  # pick a git hash / tag to point to
-      hooks:
-        - id: pydocstyle
-    - repo: https://github.com/pylint-dev/pylint
-      rev: v2.17.3
-      hooks:
-        - id: pylint
-    - repo: https://github.com/PyCQA/flake8
-      rev: c8d75d9
-      hooks:
-        - id: flake8

--- a/wrappers/setup.py
+++ b/wrappers/setup.py
@@ -2,7 +2,6 @@
 Python wrapper for tw pipelines command
 """
 from .utils import tw_run
-from pathlib import Path
 
 
 class Workspace:

--- a/wrappers/utils.py
+++ b/wrappers/utils.py
@@ -40,7 +40,7 @@ def tw_env_var(tw_variable):
     """
     Check if a tw environment variable exists
     """
-    if not tw_variable in os.environ:
+    if tw_variable not in os.environ:
         raise EnvironmentError(
             f"Tower environment variable '{tw_variable}' is not set."
         )


### PR DESCRIPTION
Just a demo to try Ruff (which I haven't had a go with yet) and see what happens. Supposedly it does 90% of Python linting very quickly.

- Adds [ruff](https://github.com/astral-sh/ruff)
- Removes everything else
- Run Ruff and fix existing files.