### PR TITLE
Fix overwrite broken for `teams`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 # Testing configs, jsons
 scripts/py/test*
-scripts/py/scidev/*/*.json
 
 # Python
 # byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
+build/lib/*
+*.egg-info/*
 
 # Commitizen
 node_modules/

--- a/tw_py/helper.py
+++ b/tw_py/helper.py
@@ -332,7 +332,10 @@ def handle_overwrite(tw, block, args):
     if block in block_operations:
         operation = block_operations[block]
         keys_to_get = operation["keys"]
-        tw_args = get_values_from_cmd_args(args, keys_to_get)
+        if block == "teams":
+            tw_args = get_values_from_cmd_args(args[0], keys_to_get)
+        else:
+            tw_args = get_values_from_cmd_args(args, keys_to_get)
         method_args = operation["method_args"](tw_args)
 
         method = getattr(tw, block)


### PR DESCRIPTION
Fixes bug with `overwrite: true` for teams where the correct keys in command line arguments parsed from the yaml can't be access correctly within the list. This is one of those subcommands that requires "special" handling to delete by `teamId` and not `name`, hence the additional steps.