### PR TITLE
Remove `--config`, fix logging, doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You will need to have an account on Nextflow Tower (see [Plans and pricing](http
   2. Launch the pipeline with `tw-pywrap`:
 
       ```
-      tw-pywrap --config hello_world_config.yml
+      tw-pywrap hello_world_config.yml
       ```
 
   3. Login to Tower Cloud and check the [Runs page](https://tower.nf/orgs/community/workspaces/showcase/watch]) in the `community/showcase` for the pipeline you just launched!
@@ -100,7 +100,7 @@ You will need to have an account on Nextflow Tower (see [Plans and pricing](http
   2. Launch the pipeline with `tw-pywrap`:
 
       ```
-      tw-pywrap --config hello_world_config.yml
+      tw-pywrap hello_world_config.yml
       ```
 
   3. Login to your Tower Enterprise instance and check the Runs page in the appropriate Workspace for the pipeline you just launched!

--- a/templates/launch.yml
+++ b/templates/launch.yml
@@ -2,13 +2,14 @@
 ## The options will vary if you are launching a pipeline:
 ##   1. Pre-configured in the Tower Launchpad where most options have already been specified
 ##   2. From source via a remote Git URL where you will need to explicitly specify all launch options
+## Note: overwrite is not supported for "tw launch"
+
 launch:
   - name: 'my_launchpad_launch'                         # required
     workspace: 'my_organization/my_workspace'           # required
     pipeline: 'my_launchpad_pipeline'                   # required
     params:                                             # optional
       outdir: 's3://my_bucket/my_results'
-    overwrite: True                                     # optional
   - name: 'my_remote_launch'                            # required
     workspace: 'my_organization/my_workspace'           # required
     compute-env: 'my_aws_compute_environment'           # required
@@ -19,4 +20,3 @@ launch:
     params-file: './pipelines/my_params.yml'            # optional
     config: './pipelines/my_nextflow.config'            # optional
     pre-run: './pipelines/my_pre_run.txt'               # optional
-    overwrite: True                                     # optional

--- a/tw_pywrap/cli.py
+++ b/tw_pywrap/cli.py
@@ -61,7 +61,7 @@ class BlockParser:
         # Check if overwrite is set to True
         overwrite = args.get("overwrite", False)
         if overwrite:
-            logging.info(f"\nOverwrite is set to 'True' for {block}\n")
+            logging.debug(f" Overwriting {block}\n")
             # Call handle_overwrite if True
             helper.handle_overwrite(self.tw, block, args["cmd_args"])
 

--- a/tw_pywrap/cli.py
+++ b/tw_pywrap/cli.py
@@ -26,7 +26,7 @@ def parse_args():
         type=str.upper,
     )
     parser.add_argument(
-        "--config", type=Path, help="Config file with Tower resources to create"
+        "yaml", type=Path, help="Config file with Tower resources to create"
     )
     return parser.parse_args()
 
@@ -89,11 +89,11 @@ def main():
             "datasets",
         ],
     )
-    with open(options.config, "r") as f:
+    with open(options.yaml, "r") as f:
         data = yaml.safe_load(f)
 
     # Returns a dict that maps block names to lists of command line arguments.
-    cmd_args_dict = helper.parse_all_yaml(options.config, list(data.keys()))
+    cmd_args_dict = helper.parse_all_yaml(options.yaml, list(data.keys()))
 
     for block, args_list in cmd_args_dict.items():
         for args in args_list:

--- a/tw_pywrap/tower.py
+++ b/tw_pywrap/tower.py
@@ -52,7 +52,7 @@ class Tower:
         full_cmd = " ".join(
             arg if arg.startswith("$") else shlex.quote(arg) for arg in command
         )
-        logging.debug(f"Running command: {full_cmd}")
+        logging.debug(f" Running command: {full_cmd}\n")
 
         # Run the command and return the stdout
         process = subprocess.Popen(full_cmd, stdout=subprocess.PIPE, shell=True)


### PR DESCRIPTION
- Removes `--config` argument from invocation of `tw-pywrap` to address #29 
- Add `logging.debug()` for `overwrite` and provide cleaner logging, re #37 
- Remove `overwrite: True` in launch template.yml, we don't support overwrite for launching of pipelines, re #35 