### PR TITLE
fix: fix retrieval of json list for datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Testing configs, jsons
 scripts/py/test*
-
+testing/*
 # Python
 # byte-compiled / optimized / DLL files
 __pycache__/

--- a/tw_pywrap/helper.py
+++ b/tw_pywrap/helper.py
@@ -357,14 +357,14 @@ def handle_overwrite(tw, block, args):
         # Return JSON data to check if resource exists
         json_method = getattr(tw, "-o json")
 
-        # TODO: refactor this
+        # TODO: (EJ) refactor this, I hate it so much
         if block == "teams":
             tw_args = get_values_from_cmd_args(args[0], keys_to_get)
             json_data = json_method(block, "list", "-o", tw_args["organization"])
-        elif block == "participants":
+        elif block in generic_deletion or block == "participants":
             tw_args = get_values_from_cmd_args(args, keys_to_get)
             json_data = json_method(block, "list", "-w", tw_args["workspace"])
-            if tw_args["type"] == "TEAM":
+            if "type" in tw_args and tw_args["type"] == "TEAM":
                 operation["name_key"] = "teamName"
         elif block == "workspaces":
             tw_args = get_values_from_cmd_args(args, keys_to_get)


### PR DESCRIPTION
Fix #44

To check if a dataset needs to be deleted, we run the `list()` method with `-o json`, for datasets we were missing a required argument to retrieve the json output which is `--workspace`. 