### PR TITLE
feat: cache json data when running list method for each block

### DIFF
--- a/tw_pywrap/cli.py
+++ b/tw_pywrap/cli.py
@@ -49,6 +49,8 @@ class BlockParser:
         """
         self.tw = tw
         self.list_for_add_method = list_for_add_method
+        # Create an instance of Overwrite class
+        self.overwrite_method = overwrite.Overwrite(self.tw)
 
     def handle_block(self, block, args):
         # Handles a block of commands by calling the appropriate function.
@@ -68,7 +70,7 @@ class BlockParser:
         overwrite_option = args.get("overwrite", False)
         if overwrite_option:
             logging.debug(f" Overwrite is set to 'True' for {block}\n")
-            overwrite.Overwrite(self.tw).handle_overwrite(block, args["cmd_args"])
+            self.overwrite_method.handle_overwrite(block, args["cmd_args"])
 
         if block in self.list_for_add_method:
             helper.handle_generic_block(self.tw, block, args["cmd_args"])

--- a/tw_pywrap/cli.py
+++ b/tw_pywrap/cli.py
@@ -70,6 +70,10 @@ class BlockParser:
         overwrite_option = args.get("overwrite", False)
         if overwrite_option:
             logging.debug(f" Overwrite is set to 'True' for {block}\n")
+            self.overwrite_method.handle_overwrite(
+                block, args["cmd_args"], overwrite_option
+            )
+        else:
             self.overwrite_method.handle_overwrite(block, args["cmd_args"])
 
         if block in self.list_for_add_method:
@@ -104,9 +108,13 @@ def main():
 
     for block, args_list in cmd_args_dict.items():
         for args in args_list:
-            # Run the methods for each block
-            block_manager.handle_block(block, args)
-            time.sleep(3)
+            try:
+                # Run the methods for each block
+                block_manager.handle_block(block, args)
+                time.sleep(3)
+            except Exception as e:
+                logging.error(e)
+                continue  # Move to the next block
 
 
 if __name__ == "__main__":

--- a/tw_pywrap/helper.py
+++ b/tw_pywrap/helper.py
@@ -55,6 +55,11 @@ def parse_block(block_name, item):
     parse_fn = block_to_function.get(block_name, parse_generic_block)
     overwrite = item.pop("overwrite", False)
 
+    # Check if the name-value pairs are unique
+    names = [key for key in item.keys() if key != "overwrite"]
+    if len(names) != len(set(names)):
+        raise ValueError(f"Duplicate name-value pairs found in the {block_name} block.")
+
     # Call the appropriate function and return its result along with overwrite value.
     cmd_args = parse_fn(item)
     return {"cmd_args": cmd_args, "overwrite": overwrite}

--- a/tw_pywrap/overwrite.py
+++ b/tw_pywrap/overwrite.py
@@ -27,10 +27,16 @@ class Overwrite:
 
         Args:
         tw: A Tower class instance.
-        block: A Tower resource name to be overwritten.
-        args: A dictionary of arguments passed to the CLI.
+
+        Attributes:
+        tw: A Tower class instance used to execute Tower CLI commands.
+        cached_jsondata: A cached placeholder for JSON data. Default value is None.
+        block_jsondata: A dictionary to store JSON data for each block.
+        Key is the block name, and value is the corresponding JSON data.
         """
         self.tw = tw
+        self.cached_jsondata = None
+        self.block_jsondata = {}  # New dict to hold JSON data per block
 
         # Define special handlers for resources deleted with specific args
         self.block_operations = {
@@ -71,13 +77,15 @@ class Overwrite:
         if block in self.block_operations:
             operation = self.block_operations[block]
             keys_to_get = operation["keys"]
-            json_data, tw_args = self._get_json_data(block, args, keys_to_get)
+            self.cached_jsondata, tw_args = self._get_json_data(
+                block, args, keys_to_get
+            )
 
             if block == "participants":
                 if tw_args.get("type") == "TEAM":
                     self.block_operations["participants"]["name_key"] = "teamName"
 
-            if self._resource_exists(json_data, operation["name_key"], tw_args):
+            if self._resource_exists(operation["name_key"], tw_args):
                 logging.debug(
                     f" The attempted {block} resource already exists. Overwriting.\n"
                 )
@@ -94,12 +102,14 @@ class Overwrite:
         Returns a list of arguments for the delete() method for teams. The teamId
         used to delete will be retrieved using the find_key_value_in_dict() method.
         """
+        jsondata = self.block_jsondata.get("teams", None)
+        if jsondata is None:
+            json_method = getattr(self.tw, "-o json")
+            json_out = json_method("teams", "-o", args["organization"])
+            self.block_jsondata["teams"] = json_out
+        # Get the teamId from the json data
         team_id = utils.find_key_value_in_dict(
-            json.loads(self.tw.teams("-o", "json", "list")),
-            "name",
-            args["name"],
-            "teamId",
-            args["organization"],
+            json.loads(json_out), "name", args["name"], "teamId"
         )
         return ("delete", "--id", str(team_id), "--organization", args["organization"])
 
@@ -155,29 +165,40 @@ class Overwrite:
 
         Returns a tuple of json data and a dictionary of values to run delete() on.
         """
-        # Return json data
         json_method = getattr(self.tw, "-o json")
 
-        # Handlers for special blocks
-        if block == "teams":
-            tw_args = self._get_values_from_cmd_args(args[0], keys_to_get)
-            json_data = json_method(block, "list", "-o", tw_args["organization"])
-        elif block in Overwrite.generic_deletion or block == "participants":
-            tw_args = self._get_values_from_cmd_args(args, keys_to_get)
-            json_data = json_method(block, "list", "-w", tw_args["workspace"])
+        # Check if block data already exists
+        if block in self.block_jsondata:
+            self.cached_jsondata = self.block_jsondata[block]
         else:
-            tw_args = self._get_values_from_cmd_args(args, keys_to_get)
-            json_data = json_method(block, "list")
+            # Fetch the data if it does not exist
+            if block == "teams":
+                tw_args = self._get_values_from_cmd_args(args[0], keys_to_get)
+                print(f"tw_args for teams are: {tw_args}")
+                self.cached_jsondata = json_method(
+                    block, "list", "-o", tw_args["organization"]
+                )
+            elif block in Overwrite.generic_deletion or block == "participants":
+                tw_args = self._get_values_from_cmd_args(args, keys_to_get)
+                self.cached_jsondata = json_method(
+                    block, "list", "-w", tw_args["workspace"]
+                )
+            else:
+                tw_args = self._get_values_from_cmd_args(args, keys_to_get)
+                self.cached_jsondata = json_method(block, "list")
 
-        # Return json data and tw_args we need to overwrite
-        return json_data, tw_args
+            # Store this data in the block_jsondata dict for later use
+            self.block_jsondata[block] = self.cached_jsondata
 
-    def _resource_exists(self, json_data, name_key, tw_args):
+            # Return json data and tw_args we need to overwrite
+            return self.cached_jsondata, tw_args
+
+    def _resource_exists(self, name_key, tw_args):
         """
         Check if a resource exists in Tower by looking for the name and value
         in the json data generated from the list() method.
         """
-        return utils.check_if_exists(json_data, name_key, tw_args["name"])
+        return utils.check_if_exists(self.cached_jsondata, name_key, tw_args["name"])
 
     def _delete_resource(self, block, operation, tw_args):
         """
@@ -205,14 +226,14 @@ class Overwrite:
                 key = None
         return values
 
-    def _find_workspace_id(self, json_data, organization, workspace_name):
+    def _find_workspace_id(self, organization, workspace_name):
         """
         Custom method to find a workspace ID in a nested dictionary with a given
         organization name and workspace name. This ID will be used to delete the
         workspace.
         """
-        if "workspaces" in json_data:
-            workspaces = json_data["workspaces"]
+        if "workspaces" in self.cached_jsondata:
+            workspaces = self.cached_jsondata["workspaces"]
             for workspace in workspaces:
                 if (
                     workspace.get("orgName") == organization

--- a/tw_pywrap/overwrite.py
+++ b/tw_pywrap/overwrite.py
@@ -178,20 +178,25 @@ class Overwrite:
                 self.cached_jsondata = json_method(
                     block, "list", "-o", tw_args["organization"]
                 )
+                return self.cached_jsondata, tw_args
+
             elif block in Overwrite.generic_deletion or block == "participants":
                 tw_args = self._get_values_from_cmd_args(args, keys_to_get)
                 self.cached_jsondata = json_method(
                     block, "list", "-w", tw_args["workspace"]
                 )
+                print(
+                    f"DEBUG: From generic deletion the json is {self.cached_jsondata}"
+                )
+                return self.cached_jsondata, tw_args
+
             else:
                 tw_args = self._get_values_from_cmd_args(args, keys_to_get)
                 self.cached_jsondata = json_method(block, "list")
+                return self.cached_jsondata, tw_args
 
-            # Store this data in the block_jsondata dict for later use
-            self.block_jsondata[block] = self.cached_jsondata
-
-            # Return json data and tw_args we need to overwrite
-            return self.cached_jsondata, tw_args
+        # Store this data in the block_jsondata dict for later use
+        self.block_jsondata[block] = self.cached_jsondata
 
     def _resource_exists(self, name_key, tw_args):
         """


### PR DESCRIPTION
Fix for #45 

- Implements json caching for `list()` method
- Use cached json to check if resource exists both before creating, and before overwriting
- Enforce unique `name: value` pairs in yaml