### PR TITLE
fix: revert skipping overwrite for pipelines

### DIFF
--- a/tw_pywrap/overwrite.py
+++ b/tw_pywrap/overwrite.py
@@ -88,9 +88,7 @@ class Overwrite:
                 else:
                     self.block_operations["participants"]["name_key"] = "email"
 
-            if block != "pipelines" and self.check_resource_exists(
-                operation["name_key"], tw_args
-            ):
+            if self.check_resource_exists(operation["name_key"], tw_args):
                 # if resource exists, delete
                 if overwrite:
                     logging.debug(

--- a/tw_pywrap/tower.py
+++ b/tw_pywrap/tower.py
@@ -68,10 +68,10 @@ class Tower:
 
         # Error handling for stdout
         if stdout:
-            if re.search(r"ERROR: (?!A pipeline).* already exists", stdout):
+            if re.search(r"ERROR: .* already exists", stdout):
                 raise ResourceExistsError(
                     " Resource already exists and will not be created."
-                    "Please set 'overwrite: true'\n"
+                    " Please set 'overwrite: true'\n"
                 )
             elif re.search(r"ERROR: .*", stdout):
                 raise ResourceCreationError(


### PR DESCRIPTION
I removed overwrite support for pipelines but in hindsight this shouldn't have been done, so adding it back. Minor changes to the `overwrite.handle_overwrite()` method to remove a conditional and error handling in `tower._tw_run()`. 